### PR TITLE
Support changelog parameters

### DIFF
--- a/tasks/db.yml
+++ b/tasks/db.yml
@@ -35,6 +35,16 @@
   when: db.index is defined
   register: result2
 
+- name: 'Apply instance configuration in cn=changelog,{{ db.name }},cn=ldbm database,cn=plugins,cn=config {{ "(I: " + instance.name + ")" }}'
+  community.general.ldap_attrs:
+    bind_dn: '{{ dm_dn }}'
+    bind_pw: '{{ dm_password }}'
+    server_uri: '{{ server_uri }}'
+    dn: 'cn=changelog,cn={{ db.name }},cn=ldbm database,cn=plugins,cn=config'
+    attributes: '{{ instance.ldbm_database.changelog }}'
+    state: exact
+  when: instance.ldbm_database.changelog is defined
+
 - name: 'Stop dirsrv service {{ "(I: " + instance.name + ", S: " + suffix.name + ", DB: " + db.name + ")" }}'
   ansible.builtin.service:
     name: 'dirsrv@{{ instance.name }}'


### PR DESCRIPTION
like nsslapd-changelogmaxage and nsslapd-changelogtrim-interval for keeping the replication changelog compact. The settings can be defined in the inventory in the group_vars. For example:
instance:
  ldbm_database:
    # settings for cn=changelog,cn=userroot,cn=ldbm database,cn=plugins,cn=config
    changelog:
      nsslapd-changelogmaxage: '4w'
      nsslapd-changelogtrim-interval: 85000

I have implemented this in the db.yml because if you want to support multiple databases per suffix then this needs to be there.